### PR TITLE
Add base interface for the definition of validators

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -3,6 +3,10 @@ export interface IValidator<T, U> {
   validate: (input: T) => IValidationError<T, U>;
 }
 
+export interface IValidatorDefinition {
+  type?: string;
+}
+
 export interface IValidationError<T, U> {
   definition: U;
   input: T;

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,11 +1,37 @@
+import {
+  IEnumValidatorDefinition,
+  IFormatValidatorDefinition,
+  IMaxItemsValidatorDefinition,
+  IMaxLengthValidatorDefinition,
+  IMaximumValidatorDefinition,
+  IMinItemsValidatorDefinition,
+  IMinLengthValidatorDefinition,
+  IMinimumValidatorDefinition,
+  IPatternValidatorDefinition,
+  IRequiredValidatorDefinition,
+} from "./";
+
 export interface IValidator<T, U> {
   definition: U;
   validate: (input: T) => IValidationError<T, U>;
 }
 
-export interface IValidatorDefinition {
+export interface IBaseValidatorDefinition {
   type?: string;
 }
+
+export type IValidatorDefinition = (
+  IEnumValidatorDefinition |
+  IFormatValidatorDefinition |
+  IMaxItemsValidatorDefinition |
+  IMaxLengthValidatorDefinition |
+  IMaximumValidatorDefinition |
+  IMinItemsValidatorDefinition |
+  IMinLengthValidatorDefinition |
+  IMinimumValidatorDefinition |
+  IPatternValidatorDefinition |
+  IRequiredValidatorDefinition
+);
 
 export interface IValidationError<T, U> {
   definition: U;

--- a/lib/validators/enum.ts
+++ b/lib/validators/enum.ts
@@ -3,12 +3,12 @@ import {
   EmptyError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IEnumValidatorDefinition extends IValidatorDefinition {
+export interface IEnumValidatorDefinition extends IBaseValidatorDefinition {
   enumerate: string[];
 }
 

--- a/lib/validators/enum.ts
+++ b/lib/validators/enum.ts
@@ -5,10 +5,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IEnumValidatorDefinition {
-  type?: string;
+export interface IEnumValidatorDefinition extends IValidatorDefinition {
   enumerate: string[];
 }
 

--- a/lib/validators/format.ts
+++ b/lib/validators/format.ts
@@ -4,10 +4,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IFormatValidatorDefinition {
-  type?: string;
+export interface IFormatValidatorDefinition extends IValidatorDefinition {
   format: string;
 }
 

--- a/lib/validators/format.ts
+++ b/lib/validators/format.ts
@@ -2,12 +2,12 @@ import {
   InvalidFormatError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IFormatValidatorDefinition extends IValidatorDefinition {
+export interface IFormatValidatorDefinition extends IBaseValidatorDefinition {
   format: string;
 }
 

--- a/lib/validators/max_items.ts
+++ b/lib/validators/max_items.ts
@@ -4,10 +4,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMaxItemsValidatorDefinition {
-  type?: string;
+export interface IMaxItemsValidatorDefinition extends IValidatorDefinition {
   maxItems: number;
 }
 

--- a/lib/validators/max_items.ts
+++ b/lib/validators/max_items.ts
@@ -2,12 +2,12 @@ import {
   NoLengthError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMaxItemsValidatorDefinition extends IValidatorDefinition {
+export interface IMaxItemsValidatorDefinition extends IBaseValidatorDefinition {
   maxItems: number;
 }
 

--- a/lib/validators/max_length.ts
+++ b/lib/validators/max_length.ts
@@ -4,10 +4,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMaxLengthValidatorDefinition {
-  type?: string;
+export interface IMaxLengthValidatorDefinition extends IValidatorDefinition {
   maxLength: number;
 }
 

--- a/lib/validators/max_length.ts
+++ b/lib/validators/max_length.ts
@@ -2,12 +2,12 @@ import {
   NoLengthError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMaxLengthValidatorDefinition extends IValidatorDefinition {
+export interface IMaxLengthValidatorDefinition extends IBaseValidatorDefinition {
   maxLength: number;
 }
 

--- a/lib/validators/maximum.ts
+++ b/lib/validators/maximum.ts
@@ -1,10 +1,10 @@
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMaximumValidatorDefinition extends IValidatorDefinition {
+export interface IMaximumValidatorDefinition extends IBaseValidatorDefinition {
   maximum: number;
   exclusive: boolean;
 }

--- a/lib/validators/maximum.ts
+++ b/lib/validators/maximum.ts
@@ -1,10 +1,10 @@
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMaximumValidatorDefinition {
-  type?: string;
+export interface IMaximumValidatorDefinition extends IValidatorDefinition {
   maximum: number;
   exclusive: boolean;
 }

--- a/lib/validators/min_items.ts
+++ b/lib/validators/min_items.ts
@@ -4,10 +4,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMinItemsValidatorDefinition {
-  type?: string;
+export interface IMinItemsValidatorDefinition extends IValidatorDefinition {
   minItems: number;
 }
 

--- a/lib/validators/min_items.ts
+++ b/lib/validators/min_items.ts
@@ -2,12 +2,12 @@ import {
   NoLengthError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMinItemsValidatorDefinition extends IValidatorDefinition {
+export interface IMinItemsValidatorDefinition extends IBaseValidatorDefinition {
   minItems: number;
 }
 

--- a/lib/validators/min_length.ts
+++ b/lib/validators/min_length.ts
@@ -2,12 +2,12 @@ import {
   NoLengthError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
 } from "../interfaces";
 
-export interface IMinLengthValidatorDefinition {
-  type?: string;
+export interface IMinLengthValidatorDefinition extends IBaseValidatorDefinition {
   minLength: number;
 }
 

--- a/lib/validators/minimum.ts
+++ b/lib/validators/minimum.ts
@@ -1,10 +1,10 @@
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMinimumValidatorDefinition {
-  type?: string;
+export interface IMinimumValidatorDefinition extends IValidatorDefinition {
   minimum: number;
   exclusive: boolean;
 }

--- a/lib/validators/minimum.ts
+++ b/lib/validators/minimum.ts
@@ -1,10 +1,10 @@
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IMinimumValidatorDefinition extends IValidatorDefinition {
+export interface IMinimumValidatorDefinition extends IBaseValidatorDefinition {
   minimum: number;
   exclusive: boolean;
 }

--- a/lib/validators/pattern.ts
+++ b/lib/validators/pattern.ts
@@ -5,10 +5,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IPatternValidatorDefinition {
-  type?: string;
+export interface IPatternValidatorDefinition extends IValidatorDefinition {
   pattern: string;
 }
 

--- a/lib/validators/pattern.ts
+++ b/lib/validators/pattern.ts
@@ -3,12 +3,12 @@ import {
   InvalidPatternError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IPatternValidatorDefinition extends IValidatorDefinition {
+export interface IPatternValidatorDefinition extends IBaseValidatorDefinition {
   pattern: string;
 }
 

--- a/lib/validators/required.ts
+++ b/lib/validators/required.ts
@@ -3,12 +3,12 @@ import {
   EmptyError,
 } from "../errors";
 import {
+  IBaseValidatorDefinition,
   IValidationError,
   IValidator,
-  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IRequiredValidatorDefinition extends IValidatorDefinition {
+export interface IRequiredValidatorDefinition extends IBaseValidatorDefinition {
   required: string[];
 }
 

--- a/lib/validators/required.ts
+++ b/lib/validators/required.ts
@@ -5,10 +5,10 @@ import {
 import {
   IValidationError,
   IValidator,
+  IValidatorDefinition,
 } from "../interfaces";
 
-export interface IRequiredValidatorDefinition {
-  type?: string;
+export interface IRequiredValidatorDefinition extends IValidatorDefinition {
   required: string[];
 }
 


### PR DESCRIPTION
Add an interface named `IValidatorDefinition` that have `type?: string` member. And all definitions extends the interface.

We can use the interface for checking which validator throws error.