### PR TITLE
Support format of password-0Aa

### DIFF
--- a/lib/validators/format.ts
+++ b/lib/validators/format.ts
@@ -22,6 +22,7 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
       case "email":
       case "hostname":
       case "uri":
+      case "password-0Aa":
         return;
       default:
         throw new InvalidFormatError(`the format is not found`);
@@ -36,19 +37,19 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
     };
     switch (format) {
 
-      case "date-time":
+      case "date-time": {
         if (FormatValidator.rDateTime.test(input)) {
           return;
         }
         break;
-
-      case "email":
+      }
+      case "email": {
         if (FormatValidator.rEmail.test(input)) {
           return;
         }
         break;
-
-      case "hostname":
+      }
+      case "hostname": {
         // stolen from https://golang.org/src/net/dnsclient.go
         const len = input.length;
         if (len === 0) {
@@ -92,12 +93,40 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
           break;
         }
         return;
-
-      case "uri":
+      }
+      case "uri": {
         if (FormatValidator.rUri.test(input)) {
           return;
         }
         break;
+      }
+      case "password-0Aa": {
+        let large = false;
+        let small = false;
+        let num = false;
+        for (let i = 0; i < input.length; i++) {
+          const c = input.charAt(i);
+          switch (true) {
+            case "0" <= c && c <= "9":
+              num = true;
+              continue;
+            case "A" <= c && c <= "Z":
+              large = true;
+              continue;
+            case "a" <= c && c <= "z":
+              small = true;
+              continue;
+            case "!" <= c && c <= "~":
+              continue;
+            default:
+              return invalid;
+          }
+        }
+        if (large && small && num) {
+          return;
+        }
+        return invalid;
+      }
 
     }
     return invalid;

--- a/test/format_test.ts
+++ b/test/format_test.ts
@@ -157,6 +157,172 @@ describe("FormatValidator", () => {
         assert.deepEqual(actual, expected);
       });
     });
+    it(`should be valid if the input value matches the password-0Aa format`, () => {
+      const definition = {
+        format: "password-0Aa",
+      };
+      const validator = new FormatValidator(definition);
+      [
+        {
+          input: "0Aa",
+          expected: undefined,
+        },
+        {
+          input: "0aA",
+          expected: undefined,
+        },
+        {
+          input: "A0a",
+          expected: undefined,
+        },
+        {
+          input: "Aa0",
+          expected: undefined,
+        },
+        {
+          input: "a0A",
+          expected: undefined,
+        },
+        {
+          input: "aA0",
+          expected: undefined,
+        },
+        {
+          input: "!0Aa",
+          expected: undefined,
+        },
+        {
+          input: "!0aA",
+          expected: undefined,
+        },
+        {
+          input: "!A0a",
+          expected: undefined,
+        },
+        {
+          input: "!Aa0",
+          expected: undefined,
+        },
+        {
+          input: "!a0A",
+          expected: undefined,
+        },
+        {
+          input: "!aA0",
+          expected: undefined,
+        },
+        {
+          input: "0!Aa",
+          expected: undefined,
+        },
+        {
+          input: "0!aA",
+          expected: undefined,
+        },
+        {
+          input: "0A!a",
+          expected: undefined,
+        },
+        {
+          input: "0Aa!",
+          expected: undefined,
+        },
+        {
+          input: "0a!A",
+          expected: undefined,
+        },
+        {
+          input: "0aA!",
+          expected: undefined,
+        },
+        {
+          input: "A!0a",
+          expected: undefined,
+        },
+        {
+          input: "A!a0",
+          expected: undefined,
+        },
+        {
+          input: "A0!a",
+          expected: undefined,
+        },
+        {
+          input: "A0a!",
+          expected: undefined,
+        },
+        {
+          input: "Aa!0",
+          expected: undefined,
+        },
+        {
+          input: "Aa0!",
+          expected: undefined,
+        },
+        {
+          input: "a!0A",
+          expected: undefined,
+        },
+        {
+          input: "a!A0",
+          expected: undefined,
+        },
+        {
+          input: "a0!A",
+          expected: undefined,
+        },
+        {
+          input: "a0A!",
+          expected: undefined,
+        },
+        {
+          input: "aA!0",
+          expected: undefined,
+        },
+        {
+          input: "aA0!",
+          expected: undefined,
+        },
+        {
+          input: "password",
+          expected: {
+            input: "password",
+            definition,
+          },
+        },
+        {
+          input: "PASSWORD",
+          expected: {
+            input: "PASSWORD",
+            definition,
+          },
+        },
+        {
+          input: "Password",
+          expected: {
+            input: "Password",
+            definition,
+          },
+        },
+        {
+          input: "passw0rd",
+          expected: {
+            input: "passw0rd",
+            definition,
+          },
+        },
+        {
+          input: "PASSW0RD",
+          expected: {
+            input: "PASSW0RD",
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
 
   });
 


### PR DESCRIPTION
Supported format of `password-0Aa`

## What is the `password-0Aa` format

**MUST** use at least one characters in:

- `0-9`
- `A-Z`
- `a-z`

**CAN** use:

ASCII characters except for white space.