### PR TITLE
Skip validate if the input is null

### DIFF
--- a/lib/validators/enum.ts
+++ b/lib/validators/enum.ts
@@ -31,15 +31,19 @@ export class EnumValidator<T> implements IValidator<{}, IEnumValidatorDefinition
   }
 
   public validate(input: T): IValidationError<T, IEnumValidatorDefinition<T>> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
     for (let i = 0; i < this.definition.enum.length; i++) {
       const e = this.definition.enum[i];
       if (e === input) {
         return;
       }
     }
-    return {
-      definition: this.definition,
-      input,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/enum.ts
+++ b/lib/validators/enum.ts
@@ -31,12 +31,12 @@ export class EnumValidator<T> implements IValidator<{}, IEnumValidatorDefinition
   }
 
   public validate(input: T): IValidationError<T, IEnumValidatorDefinition<T>> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
     for (let i = 0; i < this.definition.enum.length; i++) {
       const e = this.definition.enum[i];
@@ -44,6 +44,6 @@ export class EnumValidator<T> implements IValidator<{}, IEnumValidatorDefinition
         return;
       }
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/format.ts
+++ b/lib/validators/format.ts
@@ -32,6 +32,15 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
   }
 
   public validate(input: string): IValidationError<string, IFormatValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+
+    if (input == null) {
+      return invalid;
+    }
+
     const {format} = this.definition;
     switch (format) {
       case "date-time": {
@@ -66,10 +75,7 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
       }
 
     }
-    return {
-      definition: this.definition,
-      input,
-    };
+    return invalid;
   }
 
   // stolen from https://golang.org/src/net/dnsclient.go

--- a/lib/validators/format.ts
+++ b/lib/validators/format.ts
@@ -32,13 +32,13 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
   }
 
   public validate(input: string): IValidationError<string, IFormatValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
 
     if (input == null) {
-      return invalid;
+      return err;
     }
 
     const {format} = this.definition;
@@ -75,7 +75,7 @@ export class FormatValidator implements IValidator<string, IFormatValidatorDefin
       }
 
     }
-    return invalid;
+    return err;
   }
 
   // stolen from https://golang.org/src/net/dnsclient.go

--- a/lib/validators/max_items.ts
+++ b/lib/validators/max_items.ts
@@ -22,16 +22,16 @@ export class MaxItemsValidator implements IValidator<any, IMaxItemsValidatorDefi
   }
 
   public validate(input: IHasLength): IValidationError<any, IMaxItemsValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
     if (input.length <= this.definition.maxItems) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/max_items.ts
+++ b/lib/validators/max_items.ts
@@ -22,12 +22,16 @@ export class MaxItemsValidator implements IValidator<any, IMaxItemsValidatorDefi
   }
 
   public validate(input: IHasLength): IValidationError<any, IMaxItemsValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
     if (input.length <= this.definition.maxItems) {
       return;
     }
-    return {
-      input,
-      definition: this.definition,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/max_length.ts
+++ b/lib/validators/max_length.ts
@@ -20,12 +20,16 @@ export class MaxLengthValidator implements IValidator<string, IMaxLengthValidato
   }
 
   public validate(input: string): IValidationError<string, IMaxLengthValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
     if (input.length <= this.definition.maxLength) {
       return;
     }
-    return {
-      input,
-      definition: this.definition,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/max_length.ts
+++ b/lib/validators/max_length.ts
@@ -20,16 +20,16 @@ export class MaxLengthValidator implements IValidator<string, IMaxLengthValidato
   }
 
   public validate(input: string): IValidationError<string, IMaxLengthValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
     if (input.length <= this.definition.maxLength) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/maximum.ts
+++ b/lib/validators/maximum.ts
@@ -15,24 +15,24 @@ export class MaximumValidator implements IValidator<number, IMaximumValidatorDef
   }
 
   public validate(input: number): IValidationError<number, IMaximumValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
 
     if (!this.definition.exclusive) {
       if (input <= this.definition.maximum) {
         return;
       }
-      return invalid;
+      return err;
     }
 
     if (input < this.definition.maximum) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/maximum.ts
+++ b/lib/validators/maximum.ts
@@ -15,22 +15,24 @@ export class MaximumValidator implements IValidator<number, IMaximumValidatorDef
   }
 
   public validate(input: number): IValidationError<number, IMaximumValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
+
     if (!this.definition.exclusive) {
       if (input <= this.definition.maximum) {
         return;
       }
-      return {
-        input,
-        definition: this.definition,
-      };
+      return invalid;
     }
 
     if (input < this.definition.maximum) {
       return;
     }
-    return {
-      input,
-      definition: this.definition,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/min_items.ts
+++ b/lib/validators/min_items.ts
@@ -22,12 +22,16 @@ export class MinItemsValidator implements IValidator<any, IMinItemsValidatorDefi
   }
 
   public validate(input: IHasLength): IValidationError<any, IMinItemsValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
     if (input.length >= this.definition.minItems) {
       return;
     }
-    return {
-      input,
-      definition: this.definition,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/min_items.ts
+++ b/lib/validators/min_items.ts
@@ -22,16 +22,16 @@ export class MinItemsValidator implements IValidator<any, IMinItemsValidatorDefi
   }
 
   public validate(input: IHasLength): IValidationError<any, IMinItemsValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
     if (input.length >= this.definition.minItems) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/min_length.ts
+++ b/lib/validators/min_length.ts
@@ -20,16 +20,16 @@ export class MinLengthValidator implements IValidator<string, IMinLengthValidato
   }
 
   public validate(input: string): IValidationError<string, IMinLengthValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
     if (input.length >= this.definition.minLength) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/min_length.ts
+++ b/lib/validators/min_length.ts
@@ -20,12 +20,16 @@ export class MinLengthValidator implements IValidator<string, IMinLengthValidato
   }
 
   public validate(input: string): IValidationError<string, IMinLengthValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
     if (input.length >= this.definition.minLength) {
       return;
     }
-    return {
-      input,
-      definition: this.definition,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/minimum.ts
+++ b/lib/validators/minimum.ts
@@ -15,22 +15,24 @@ export class MinimumValidator implements IValidator<number, IMinimumValidatorDef
   }
 
   public validate(input: number): IValidationError<number, IMinimumValidatorDefinition> {
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
+    if (input == null) {
+      return invalid;
+    }
+
     if (!this.definition.exclusive) {
       if (input >= this.definition.minimum) {
         return;
       }
-      return {
-        input,
-        definition: this.definition,
-      };
+      return invalid;
     }
 
     if (input > this.definition.minimum) {
       return;
     }
-    return {
-      input,
-      definition: this.definition,
-    };
+    return invalid;
   }
 }

--- a/lib/validators/minimum.ts
+++ b/lib/validators/minimum.ts
@@ -15,24 +15,24 @@ export class MinimumValidator implements IValidator<number, IMinimumValidatorDef
   }
 
   public validate(input: number): IValidationError<number, IMinimumValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
 
     if (!this.definition.exclusive) {
       if (input >= this.definition.minimum) {
         return;
       }
-      return invalid;
+      return err;
     }
 
     if (input > this.definition.minimum) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/pattern.ts
+++ b/lib/validators/pattern.ts
@@ -29,12 +29,16 @@ export class PatternValidator implements IValidator<string, IPatternValidatorDef
   }
 
   public validate(input: string): IValidationError<string, IPatternValidatorDefinition> {
-    if (this.regExp.test(input)) {
-      return;
-    }
-    return {
+    const invalid = {
       definition: this.definition,
       input,
     };
+    if (input == null) {
+      return invalid;
+    }
+    if (this.regExp.test(input)) {
+      return;
+    }
+    return invalid;
   }
 }

--- a/lib/validators/pattern.ts
+++ b/lib/validators/pattern.ts
@@ -29,16 +29,16 @@ export class PatternValidator implements IValidator<string, IPatternValidatorDef
   }
 
   public validate(input: string): IValidationError<string, IPatternValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
     if (input == null) {
-      return invalid;
+      return err;
     }
     if (this.regExp.test(input)) {
       return;
     }
-    return invalid;
+    return err;
   }
 }

--- a/lib/validators/present.ts
+++ b/lib/validators/present.ts
@@ -21,7 +21,7 @@ export class PresentValidator implements IValidator<any, IPresentValidatorDefini
   }
 
   public validate(input: any): IValidationError<any, IPresentValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
@@ -31,7 +31,7 @@ export class PresentValidator implements IValidator<any, IPresentValidatorDefini
       (isArray(input) && input.length === 0) ||
       (isObject(input) && Object.keys(input).length === 0)
     ) {
-      return invalid;
+      return err;
     }
     return;
   }

--- a/lib/validators/required.ts
+++ b/lib/validators/required.ts
@@ -33,13 +33,13 @@ export class RequiredValidator implements IValidator<any, IRequiredValidatorDefi
   }
 
   public validate(input: any): IValidationError<any, IRequiredValidatorDefinition> {
-    const invalid = {
+    const err = {
       definition: this.definition,
       input,
     };
 
     if (input == null) {
-      return invalid;
+      return err;
     }
 
     const {required} = this.definition;
@@ -48,7 +48,7 @@ export class RequiredValidator implements IValidator<any, IRequiredValidatorDefi
       const key = required[i];
       const presentError = present.validate(input[key]);
       if (presentError != null) {
-        return invalid;
+        return err;
       }
     }
     return;

--- a/lib/validators/required.ts
+++ b/lib/validators/required.ts
@@ -32,18 +32,22 @@ export class RequiredValidator implements IValidator<any, IRequiredValidatorDefi
   }
 
   public validate(input: any): IValidationError<any, IRequiredValidatorDefinition> {
-    const {required} = this.definition;
+    const invalid = {
+      definition: this.definition,
+      input,
+    };
 
+    if (input == null) {
+      return invalid;
+    }
+
+    const {required} = this.definition;
     for (let i = 0; i < required.length; i++) {
       const key = required[i];
       if (input[key] == null) {
-        return {
-          definition: this.definition,
-          input,
-        };
+        return invalid;
       }
     }
-
     return;
   }
 }

--- a/lib/validators/required.ts
+++ b/lib/validators/required.ts
@@ -7,6 +7,7 @@ import {
   IValidationError,
   IValidator,
 } from "../interfaces";
+import {PresentValidator} from "./present";
 
 export interface IRequiredValidatorDefinition extends IBaseValidatorDefinition {
   required: string[];
@@ -42,9 +43,11 @@ export class RequiredValidator implements IValidator<any, IRequiredValidatorDefi
     }
 
     const {required} = this.definition;
+    const present = new PresentValidator({});
     for (let i = 0; i < required.length; i++) {
       const key = required[i];
-      if (input[key] == null) {
+      const presentError = present.validate(input[key]);
+      if (presentError != null) {
         return invalid;
       }
     }

--- a/test/enum_test.ts
+++ b/test/enum_test.ts
@@ -42,6 +42,36 @@ describe("EnumValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        enum: [
+          "foo",
+          "bar",
+          "baz",
+        ],
+      };
+      const validator = new EnumValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the input value exists in the enum values`, () => {
       const definition = {
         enum: [

--- a/test/format_test.ts
+++ b/test/format_test.ts
@@ -6,6 +6,32 @@ describe("FormatValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        format: "date-time",
+      };
+      const validator = new FormatValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the input value matches the date-time format`, () => {
       const definition = {
         format: "date-time",

--- a/test/max_items_test.ts
+++ b/test/max_items_test.ts
@@ -24,6 +24,32 @@ describe("MaxItemsValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        maxItems: 3,
+      };
+      const validator = new MaxItemsValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the size of the input is less than, or or equal to, the value of maxItems`, () => {
       const definition = {
         maxItems: 3,

--- a/test/max_length_test.ts
+++ b/test/max_length_test.ts
@@ -24,6 +24,32 @@ describe("MaxLengthValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        maxLength: 3,
+      };
+      const validator = new MaxLengthValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the length of the input value is lower than the max length`, () => {
       const definition = {
         maxLength: 3,

--- a/test/maximum_test.ts
+++ b/test/maximum_test.ts
@@ -5,6 +5,33 @@ import {MaximumValidator} from "../lib/validators/maximum";
 describe("MaximumValidator", () => {
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        maximum: 100,
+        exclusive: false,
+      };
+      const validator = new MaximumValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     describe("without exclusive", () => {
 
       it(`should be valid if the input value is lower than, or equal to the maximum value`, () => {

--- a/test/min_items_test.ts
+++ b/test/min_items_test.ts
@@ -24,6 +24,32 @@ describe("MinItemsValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        minItems: 3,
+      };
+      const validator = new MinItemsValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the size of the input is less than, or or equal to, the value of minItems`, () => {
       const definition = {
         minItems: 3,

--- a/test/min_length_test.ts
+++ b/test/min_length_test.ts
@@ -24,6 +24,32 @@ describe("MinLengthValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        minLength: 3,
+      };
+      const validator = new MinLengthValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the length of the input value is greater than the minimum length`, () => {
       const definition = {
         minLength: 3,

--- a/test/minimum_test.ts
+++ b/test/minimum_test.ts
@@ -5,6 +5,33 @@ import {MinimumValidator} from "../lib/validators/minimum";
 describe("MinimumValidator", () => {
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        minimum: 100,
+        exclusive: false,
+      };
+      const validator = new MinimumValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     describe("without exclusive", () => {
 
       it(`should be valid if the input value is larger than, or equal to the minimum value`, () => {

--- a/test/pattern_test.ts
+++ b/test/pattern_test.ts
@@ -31,6 +31,32 @@ describe("PatternValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        pattern: "^\\d{7}$",
+      };
+      const validator = new PatternValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the input value matches the regular expression`, () => {
       const definition = {
         pattern: "^\\d{7}$",

--- a/test/required_test.ts
+++ b/test/required_test.ts
@@ -104,14 +104,6 @@ describe("RequiredValidator", () => {
           input: {
             foo: 123,
             bar: 456,
-            hoge: "",
-          },
-          expected: null,
-        },
-        {
-          input: {
-            foo: 123,
-            bar: 456,
             hoge: false,
           },
           expected: null,
@@ -125,6 +117,21 @@ describe("RequiredValidator", () => {
             input: {
               foo: 123,
               bar: 456,
+            },
+            definition,
+          },
+        },
+        {
+          input: {
+            foo: 123,
+            bar: 456,
+            hoge: "",
+          },
+          expected: {
+            input: {
+              foo: 123,
+              bar: 456,
+              hoge: "",
             },
             definition,
           },

--- a/test/required_test.ts
+++ b/test/required_test.ts
@@ -44,6 +44,36 @@ describe("RequiredValidator", () => {
 
   describe("validate()", () => {
 
+    it(`should be valid if the input value is null`, () => {
+      const definition = {
+        required: [
+          "foo",
+          "bar",
+          "hoge",
+        ],
+      };
+      const validator = new RequiredValidator(definition);
+      [
+        {
+          input: null,
+          expected: {
+            input: null,
+            definition,
+          },
+        },
+        {
+          input: undefined,
+          expected: {
+            input: undefined,
+            definition,
+          },
+        },
+      ].forEach(({input, expected}) => {
+        const actual = validator.validate(input);
+        assert.deepEqual(actual, expected);
+      });
+    });
+
     it(`should be valid if the input has required keys`, () => {
       const definition = {
         required: [


### PR DESCRIPTION
In order to avoid `no method error` when the input is null, each validators return error if the input value is null.